### PR TITLE
Feat comunicação do customer id entre microservices

### DIFF
--- a/pagamento/src/main/java/br/com/iouone/pagamento/requests/CustomerIdMessageRequest.java
+++ b/pagamento/src/main/java/br/com/iouone/pagamento/requests/CustomerIdMessageRequest.java
@@ -1,0 +1,28 @@
+package br.com.iouone.pagamento.requests;
+
+public class CustomerIdMessageRequest {
+
+    private Integer pessoaId;
+    private String customerId;
+
+    public CustomerIdMessageRequest(Integer pessoaId, String customerId) {
+        this.pessoaId = pessoaId;
+        this.customerId = customerId;
+    }
+
+    public Integer getPessoaId() {
+        return pessoaId;
+    }
+
+    public void setPessoaId(Integer pessoaId) {
+        this.pessoaId = pessoaId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
+    }
+}

--- a/pagamento/src/main/java/br/com/iouone/pagamento/requests/CustomerRequest.java
+++ b/pagamento/src/main/java/br/com/iouone/pagamento/requests/CustomerRequest.java
@@ -1,6 +1,8 @@
 package br.com.iouone.pagamento.requests;
 
 public class CustomerRequest {
+
+    private Integer id;
     private String name;
     private String email;
     private String document;
@@ -20,6 +22,14 @@ public class CustomerRequest {
         this.gender = gender;
         this.birthdate = birthdate;
         this.celular = celular;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
     }
 
     public String getName() {


### PR DESCRIPTION
feat: adicionar campo `id` em CustomerRequest e enviar CustomerId após criação no Pagar.me

- Adicionado o campo `id` à classe `CustomerRequest` para armazenar o identificador da pessoa.
- Implementados os métodos getters e setters para o campo `id`.
- Injetado `RabbitTemplate` no `ClienteService` para permitir o envio de mensagens.
- Atualizada a lógica no `ClienteService` para enviar um `CustomerIdMessageRequest` com o ID do cliente local e o ID criado no Pagar.me para a fila `receiving_customer_id_queue` após a criação bem-sucedida do cliente.
- Adicionadas mensagens de log para monitorar o envio do ID do cliente para o microservice de Cliente.